### PR TITLE
Use Python standard libraries to handle OS-specific operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# temp dir
+temp/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you re-arranged the frames of [Steamed Hams](https://www.youtube.com/watch?v=
 STAMMER is a python utility for recreating any audio source with the frames of any other audio or video source.
 For each frame in the audio source being recreated, STAMMER selects the frame in the source audio with the most similar spectrum, adjusts its volume as needed, and inserts that frame into the output. Despite its name, STAMMER works on any audio, not just Steamed Hams.
 
-## Instructions (MacOS/Linux)
+## Instructions
 
 STAMMER requires python 3, and the following python libraries:
 


### PR DESCRIPTION
`pathlib` handles Windows and Unix paths by default.

`shutil` can do copy and rmtree.

`subprocess` takes care of OS command-line specific differences (I was noticing issues using filenames with spaces before on Windows).

This basically eliminates all of the OS-specific code and lets Python take care of it, so it should be much more reliable.

(Tested on Windows & Ubuntu)