### PR TITLE
Inform user for temp dir + work audio in mem + audio only output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ python stammer.py <carrier track> <modulator track> <output file>
 where `<carrier track>` is the path to an audio or video file that frames will be taken from (i.e. Steamed Hams in the above example), `<modulator track>` is the path to an audio or video file that will be reconstructed using the carrier track, and `<output file>` is a path to file that will be written to. `<output file>` should have an audio or video file extension (such as `.wav`, `.mp3`, `.mp4`, etc).
 
 ### Warnings
+At the start of its operation, STAMMER creates a directory called `temp`, where it writes files to work. At the end of its operation, STAMMER will delete this directory. However, if the program is forcefully terminated or crashes during operation, this directory will still exist.
 
-During its operation, STAMMER creates a directory called `temp`, where it writes files. At the end of its operation, STAMMER will delete this directory. However, if the program is terminated or crashes during operation, this directory will still exist and will need to be deleted by the user.
+Another case where `temp` unexpectedly remains is when trying to run two instances of STAMMER on the same machine at once; the result is that they will race to overwrite eachother's files.
 
-Because of this, running two instances of STAMMER on the same machine at once will lead to errors, as files will get overwritten.
+STAMMER isn't designed to cope with this, so STAMMER will only work when `temp` doesn't already exist. Otherwise, it will warn you to _delete the directory yourself._
 
-There are plans to solve this in future versions of STAMMER by storing the data in memory instead of on disk.
+There are plans to solve this in future versions of STAMMER by keeping necessary data in memory instead of on disk, and/or creating uniquely-named temporary folders.
 
 ## Why and How
 

--- a/stammer.py
+++ b/stammer.py
@@ -169,6 +169,7 @@ def get_audio_as_wav_bytes(path):
             '-hide_banner',
             '-loglevel', 'error',
             '-i', path,
+            '-vn', '-map', '0:a:0',
             '-ac', '1',
             '-ar', str(INTERNAL_SAMPLERATE),
             '-c:a', 'pcm_s16le',

--- a/stammer.py
+++ b/stammer.py
@@ -146,6 +146,20 @@ def create_output_audio(best_matches, modulator_audio, carrier_frames, modulator
 
     wavfile.write(TEMP_DIR / 'out.wav', INTERNAL_SAMPLERATE, output_audio)
 
+COMMON_AUDIO_EXTS = [
+    "wav",
+    "wv",
+    "mp3",
+    "m4a",
+    "aac",
+    "ogg",
+    "opus",
+]
+
+def is_audio_filename(name):
+    import os.path
+    return os.path.splitext(name)[1][1:] in COMMON_AUDIO_EXTS
+
 def get_audio_as_wav_bytes(path):
     import io
 
@@ -168,35 +182,38 @@ def get_audio_as_wav_bytes(path):
 
     return io.BytesIO(bytes(ff_out))
 
-
 def process(carrier_path, modulator_path, output_path):
     if not carrier_path.is_file():
         raise FileNotFoundError(f"Carrier file {carrier_path} not found.")
     if not modulator_path.is_file():
         raise FileNotFoundError(f"Modulator file {modulator_path} not found.")
-
-
     carrier_type = file_type(carrier_path)
     modulator_type = file_type(modulator_path)
 
     if 'video' in carrier_type:
-        carrier_is_video = True
-        print("Separating video frames")
-        frames_dir = TEMP_DIR / 'frames'
-        frames_dir.mkdir()
-        subprocess.run(
-            [
-                'ffmpeg',
-                '-loglevel', 'error',
-                '-i', carrier_path,
-                frames_dir / 'frame%06d.png'
-            ],
-            check=True
-        )
+        output_is_audio = is_audio_filename(output_path)
+        carrier_is_video = not output_is_audio
+
+        print("Calculating video length")
         carrier_duration = float(get_duration(carrier_path))
         carrier_framecount = float(get_framecount(carrier_path))
 
-        frame_length = carrier_duration / carrier_framecount        
+        if not output_is_audio:
+            print("Separating video frames")
+            frames_dir = TEMP_DIR / 'frames'
+            frames_dir.mkdir()
+            subprocess.run(
+                [
+                    'ffmpeg',
+                    '-loglevel', 'error',
+                    '-i', carrier_path,
+                    frames_dir / 'frame%06d.png'
+                ],
+                check=True
+            )
+
+        frame_length = carrier_duration / carrier_framecount
+
 
     elif 'audio' in carrier_type:
         carrier_is_video = False

--- a/stammer.py
+++ b/stammer.py
@@ -274,13 +274,17 @@ def main():
     parser.add_argument('output_path', type=Path, metavar='output_file', help='path to file that will be written to; should have an audio or video file extension (such as .wav, .mp3, .mp4, etc.)')
     args = parser.parse_args()
     
-    try:
-        TEMP_DIR.mkdir()
-        process(**vars(args))
-        shutil.rmtree(TEMP_DIR)
-    except Exception:
-        shutil.rmtree(TEMP_DIR, ignore_errors=True)  # no guarantee that temp/ was created
-        raise
+    import os.path
+    if (os.path.isdir(TEMP_DIR)):
+        print("\
+The \"temp\" directory already exists.\n\
+This may indicate that STAMMER recently crashed,\n\
+or you are currently running another instance of STAMMER (this is not supported).\n\
+If possible, delete the \"temp\" directory to continue.")
+        return
+    TEMP_DIR.mkdir()
+    process(**vars(args))
+    shutil.rmtree(TEMP_DIR)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Coalesces #16 #17 and #18 into one PR.

#16:
- Allow carrier to be a video while exporting as audio-only.
- Fixes #5

#17:
- Write initial carrier/modulator WAVs directly to memory
- Part of #11 (need to work on video later)

#18:
- If temp dir exists, the program will not start, and an explanation message will display.
- README is edited to reflect this
- Fixes #3

This also, hopefully, helps with #9 by excluding video on the ffmpeg side when making WAVs.