### PR TITLE
Use `tempfile` instead of temp + Add extensions to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,17 @@ dmypy.json
 
 # temp dir
 temp/
+
+# Audio and video
+*.mp4
+*.mkv
+*.webm
+*.avi
+*.wav
+*.wv
+*.flac
+*.m4a
+*.aac
+*.mp3
+*.ogg
+*.opus

--- a/README.md
+++ b/README.md
@@ -26,15 +26,6 @@ python stammer.py <carrier track> <modulator track> <output file>
 
 where `<carrier track>` is the path to an audio or video file that frames will be taken from (i.e. Steamed Hams in the above example), `<modulator track>` is the path to an audio or video file that will be reconstructed using the carrier track, and `<output file>` is a path to file that will be written to. `<output file>` should have an audio or video file extension (such as `.wav`, `.mp3`, `.mp4`, etc).
 
-### Warnings
-At the start of its operation, STAMMER creates a directory called `temp`, where it writes files to work. At the end of its operation, STAMMER will delete this directory. However, if the program is forcefully terminated or crashes during operation, this directory will still exist.
-
-Another case where `temp` unexpectedly remains is when trying to run two instances of STAMMER on the same machine at once; the result is that they will race to overwrite eachother's files.
-
-STAMMER isn't designed to cope with this, so STAMMER will only work when `temp` doesn't already exist. Otherwise, it will warn you to _delete the directory yourself._
-
-There are plans to solve this in future versions of STAMMER by keeping necessary data in memory instead of on disk, and/or creating uniquely-named temporary folders.
-
 ## Why and How
 
 For several years, making increasingly outlandish edits of the skit "Steamed Hams" from *The Simpsons* has been a [trend online](https://knowyourmeme.com/memes/steamed-hams). This project was primarily inspired by an edit of "Steamed Hams" in which [the frames were sorted by pitch](https://www.youtube.com/watch?v=iWFRKZek0FI). It really is worth a listen: the choppy untintelligible vocals, steadily rising in pitch, builds tension in a strange way. Even chopped to the granularity of a frame, the music stabs and dialogue from the skit is still recognizable.

--- a/stammer.py
+++ b/stammer.py
@@ -4,6 +4,7 @@ from scipy.io import wavfile
 from pathlib import Path
 import shutil
 import subprocess
+import tempfile
 
 TEMP_DIR = Path('temp')
 
@@ -274,18 +275,11 @@ def main():
     parser.add_argument('modulator_path', type=Path, metavar='modulator_track', help='path to an audio or video file that will be reconstructed using the carrier track')
     parser.add_argument('output_path', type=Path, metavar='output_file', help='path to file that will be written to; should have an audio or video file extension (such as .wav, .mp3, .mp4, etc.)')
     args = parser.parse_args()
-    
-    import os.path
-    if (os.path.isdir(TEMP_DIR)):
-        print("\
-The \"temp\" directory already exists.\n\
-This may indicate that STAMMER recently crashed,\n\
-or you are currently running another instance of STAMMER (this is not supported).\n\
-If possible, delete the \"temp\" directory to continue.")
-        return
-    TEMP_DIR.mkdir()
-    process(**vars(args))
-    shutil.rmtree(TEMP_DIR)
+    with tempfile.TemporaryDirectory() as tempdir:
+        global TEMP_DIR
+        TEMP_DIR = Path(tempdir)
+        process(**vars(args))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Using then hardcoded name `temp` was a terrible idea from the beginning. Luckily, there's a built-in python module that takes care of that specific need. Also, I added a bunch of filename extensions associated with audio and video files, in case someone wants to stage all new/updated files while having a bunch of output files there.