### PR TITLE
Adds IEC A-weighting and replaces FFT with RFFT

### DIFF
--- a/audio_matching.py
+++ b/audio_matching.py
@@ -215,10 +215,17 @@ class WeightedAudioMatcher(BasicAudioMatcher):
         normalized_bands = spectra / vector_magnitudes[:,None]
     
         return normalized_bands
-
-    def best_match(self, modulator_band):
+    
+    def find_matches(self):
         freqs = np.fft.rfftfreq(2 * self.samples_per_frame, 1. / self.samplerate)[1:]
-        weights = self.r_a(freqs)
+        weights = self.a_weighting(freqs)
+        self.best_matches = []
+        inv_len = 1.0/len(self.modulator_bands)
+        for i in range(len(self.modulator_bands)):
+            self.best_matches.append(self.best_match(self.modulator_bands[i], weights))
+            self.print_progress(inv_len,i)
+
+    def best_match(self, modulator_band, weights):
         dot_products = np.sum(weights * (self.carrier_bands * modulator_band), axis=1)
         best = np.argmax(dot_products)
         return best


### PR DESCRIPTION
Some formants (especially sibilants) were being lost by the basic audio matcher, and I suspected this was because the progressive frequency binning was giving too much weight to low-frequency (even infrasonic) components. To that end I added a "weighted" matcher subclass, which keeps all of the original FFT bins and then applies [IEC A-weighting](https://en.wikipedia.org/wiki/A-weighting) to the cosine similarity. I've attached an example of the output for comparison.

https://github.com/ArdenButterfield/stammer/assets/16582285/36759b1c-a32b-4f4d-af01-c2cce975f5fc

Also, I noticed that the two-sided numpy FFT was being computed and then sliced down to the positive frequency components; I replaced this with numpy.fft.rfft, which is identical for real signals and a little bit faster with less array slicing.

Best,
Moonjail